### PR TITLE
add newPackage(String basename) function

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Creates a resource XML file, which contains `dict`.
 
 Prases or reads a version object, which has `toVersionCode()` and `toVersionName()` methods.
 
+### `Package newPackage(String basename)`
+
+Package name builder, which has `getSimpleName(String namespace)` and `getSimpleName(String namespace, basename)` methods.
+
 # SEE ALSO
 
 * https://github.com/gfx/Android-HankeiN which uses this project

--- a/build.gradle
+++ b/build.gradle
@@ -106,3 +106,35 @@ ext.readVersion = { File file ->
     def s = new String(file.readBytes())
     return parseVersion(s)
 }
+
+
+
+public class Package {
+    public final String basename;
+
+    public Package(String name) {
+        basename = name
+    }
+
+    public String getSimpleName(String namespace) {
+        return basename + namespace;
+    }
+
+    public String getSimpleName(String namespace, String basename) {
+        return basename + namespace
+    }
+
+    public boolean isBasenameEmpty() {
+        return basename == '';
+    }
+
+    @Override
+    public String toString() {
+        return basename;
+    }
+}
+
+ext.newPackage = { String basename ->
+    return new Package(basename)
+}
+

--- a/test/test.gradle
+++ b/test/test.gradle
@@ -42,3 +42,13 @@ check.dependsOn(task("readVersion") << {
     assert v.toString() == "1.2.30 (1002030)"
 })
 
+check.dependsOn(task("newPackage") <<{
+    def basename = "com.example"
+    def namespace = ".app.mypackage"
+    def anotherBasename = "net.sample"
+    def app = newPackage(basename)
+    assert app.basename == basename
+    assert app.getSimpleName(namespace) == basename + namespace
+    assert app.getSimpleName(namespace, anotherBasename) == anotherBasename + namespace
+})
+


### PR DESCRIPTION
For example to use case for `AndroidManifest.xml`,
- Dynamic build to package name with `writeResource()`
- For `authorities` property in `<provider>` attribute
  - to be install to multiple buildTypes application in gadget. _[fix for it](http://stackoverflow.com/questions/16777534/using-build-types-in-gradle-to-run-same-app-that-uses-contentprovider-on-one-dev)_

What do you think? :)
