### PR TITLE
Don't generate image if outputFile exists

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ private int toGray(color) {
 }
 
 ext.iconToGrayScale = { File inputFile, File outputFile ->
+    if (outputFile.exists()) {
+        return;
+    }
+
     def img = ImageIO.read(inputFile)
     for (int y = 0; y < img.getHeight(); y++) {
         for (int x = 0; x < img.getWidth(); x++) {


### PR DESCRIPTION
makeGrayscaleLauncherIcon is so good, but it doesn't look that the task dosen't have to generate icon every build time.
