### PR TITLE
Support product flavor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,8 @@ ext.iconToGrayScale = { File inputFile, File outputFile ->
 ext.makeGrayscaleLauncherIcon = { File dir, String name, List<String> buildTypes = ["debug"] ->
     fileTree(dir: dir, include: "res/drawable*/$name").each { File ic ->
         buildTypes.each { String buildType ->
-            def outputFile = file(ic.getPath().replaceAll("/main/", "/$buildType/"))
+            String flavor = dir.getName();
+            def outputFile = file(ic.getPath().replaceAll("/$flavor/", "/$buildType/"))
             iconToGrayScale(ic, outputFile)
         }
     }


### PR DESCRIPTION
makeGrayscaleLauncherIcon() is only support main product flavor.
This PR for supporting other product flavor of main.

```groovy
makeGrayscaleLauncherIcon(file("src/free"), "ic_launcher.png", ["freeDebug"])
```